### PR TITLE
Revert "Bump vite from 4.5.1 to 5.0.7"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
                 "eslint-plugin-react": "^7.33.2",
                 "eslint-plugin-react-hooks": "^4.6.0",
                 "laravel-vite-plugin": "^0.8.0",
-                "vite": "^5.0.7"
+                "vite": "^4.0.0"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -361,9 +361,9 @@
             }
         },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.19.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.9.tgz",
-            "integrity": "sha512-jkYjjq7SdsWuNI6b5quymW0oC83NN5FdRPuCbs9HZ02mfVdAP8B8eeqLSYU3gb6OJEaY5CQabtTFbqBf26H3GA==",
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+            "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
             "cpu": [
                 "arm"
             ],
@@ -376,9 +376,9 @@
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.19.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.9.tgz",
-            "integrity": "sha512-q4cR+6ZD0938R19MyEW3jEsMzbb/1rulLXiNAJQADD/XYp7pT+rOS5JGxvpRW8dFDEfjW4wLgC/3FXIw4zYglQ==",
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+            "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
             "cpu": [
                 "arm64"
             ],
@@ -391,9 +391,9 @@
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.19.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.9.tgz",
-            "integrity": "sha512-KOqoPntWAH6ZxDwx1D6mRntIgZh9KodzgNOy5Ebt9ghzffOk9X2c1sPwtM9P+0eXbefnDhqYfkh5PLP5ULtWFA==",
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+            "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
             "cpu": [
                 "x64"
             ],
@@ -406,9 +406,9 @@
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.19.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.9.tgz",
-            "integrity": "sha512-KBJ9S0AFyLVx2E5D8W0vExqRW01WqRtczUZ8NRu+Pi+87opZn5tL4Y0xT0mA4FtHctd0ZgwNoN639fUUGlNIWw==",
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+            "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
             "cpu": [
                 "arm64"
             ],
@@ -421,9 +421,9 @@
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.19.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.9.tgz",
-            "integrity": "sha512-vE0VotmNTQaTdX0Q9dOHmMTao6ObjyPm58CHZr1UK7qpNleQyxlFlNCaHsHx6Uqv86VgPmR4o2wdNq3dP1qyDQ==",
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+            "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
             "cpu": [
                 "x64"
             ],
@@ -436,9 +436,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.19.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.9.tgz",
-            "integrity": "sha512-uFQyd/o1IjiEk3rUHSwUKkqZwqdvuD8GevWF065eqgYfexcVkxh+IJgwTaGZVu59XczZGcN/YMh9uF1fWD8j1g==",
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+            "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
             "cpu": [
                 "arm64"
             ],
@@ -451,9 +451,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.19.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.9.tgz",
-            "integrity": "sha512-WMLgWAtkdTbTu1AWacY7uoj/YtHthgqrqhf1OaEWnZb7PQgpt8eaA/F3LkV0E6K/Lc0cUr/uaVP/49iE4M4asA==",
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+            "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
             "cpu": [
                 "x64"
             ],
@@ -466,9 +466,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.19.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.9.tgz",
-            "integrity": "sha512-C/ChPohUYoyUaqn1h17m/6yt6OB14hbXvT8EgM1ZWaiiTYz7nWZR0SYmMnB5BzQA4GXl3BgBO1l8MYqL/He3qw==",
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+            "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
             "cpu": [
                 "arm"
             ],
@@ -481,9 +481,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.19.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.9.tgz",
-            "integrity": "sha512-PiPblfe1BjK7WDAKR1Cr9O7VVPqVNpwFcPWgfn4xu0eMemzRp442hXyzF/fSwgrufI66FpHOEJk0yYdPInsmyQ==",
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+            "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
             "cpu": [
                 "arm64"
             ],
@@ -496,9 +496,9 @@
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.19.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.9.tgz",
-            "integrity": "sha512-f37i/0zE0MjDxijkPSQw1CO/7C27Eojqb+r3BbHVxMLkj8GCa78TrBZzvPyA/FNLUMzP3eyHCVkAopkKVja+6Q==",
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+            "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
             "cpu": [
                 "ia32"
             ],
@@ -511,9 +511,9 @@
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.19.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.9.tgz",
-            "integrity": "sha512-t6mN147pUIf3t6wUt3FeumoOTPfmv9Cc6DQlsVBpB7eCpLOqQDyWBP1ymXn1lDw4fNUSb/gBcKAmvTP49oIkaA==",
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+            "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
             "cpu": [
                 "loong64"
             ],
@@ -526,9 +526,9 @@
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.19.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.9.tgz",
-            "integrity": "sha512-jg9fujJTNTQBuDXdmAg1eeJUL4Jds7BklOTkkH80ZgQIoCTdQrDaHYgbFZyeTq8zbY+axgptncko3v9p5hLZtw==",
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+            "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
             "cpu": [
                 "mips64el"
             ],
@@ -541,9 +541,9 @@
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.19.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.9.tgz",
-            "integrity": "sha512-tkV0xUX0pUUgY4ha7z5BbDS85uI7ABw3V1d0RNTii7E9lbmV8Z37Pup2tsLV46SQWzjOeyDi1Q7Wx2+QM8WaCQ==",
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+            "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
             "cpu": [
                 "ppc64"
             ],
@@ -556,9 +556,9 @@
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.19.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.9.tgz",
-            "integrity": "sha512-DfLp8dj91cufgPZDXr9p3FoR++m3ZJ6uIXsXrIvJdOjXVREtXuQCjfMfvmc3LScAVmLjcfloyVtpn43D56JFHg==",
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+            "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
             "cpu": [
                 "riscv64"
             ],
@@ -571,9 +571,9 @@
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.19.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.9.tgz",
-            "integrity": "sha512-zHbglfEdC88KMgCWpOl/zc6dDYJvWGLiUtmPRsr1OgCViu3z5GncvNVdf+6/56O2Ca8jUU+t1BW261V6kp8qdw==",
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+            "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
             "cpu": [
                 "s390x"
             ],
@@ -586,9 +586,9 @@
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.19.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.9.tgz",
-            "integrity": "sha512-JUjpystGFFmNrEHQnIVG8hKwvA2DN5o7RqiO1CVX8EN/F/gkCjkUMgVn6hzScpwnJtl2mPR6I9XV1oW8k9O+0A==",
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+            "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
             "cpu": [
                 "x64"
             ],
@@ -601,9 +601,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.19.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.9.tgz",
-            "integrity": "sha512-GThgZPAwOBOsheA2RUlW5UeroRfESwMq/guy8uEe3wJlAOjpOXuSevLRd70NZ37ZrpO6RHGHgEHvPg1h3S1Jug==",
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+            "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
             "cpu": [
                 "x64"
             ],
@@ -616,9 +616,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.19.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.9.tgz",
-            "integrity": "sha512-Ki6PlzppaFVbLnD8PtlVQfsYw4S9n3eQl87cqgeIw+O3sRr9IghpfSKY62mggdt1yCSZ8QWvTZ9jo9fjDSg9uw==",
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+            "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
             "cpu": [
                 "x64"
             ],
@@ -631,9 +631,9 @@
             }
         },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.19.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.9.tgz",
-            "integrity": "sha512-MLHj7k9hWh4y1ddkBpvRj2b9NCBhfgBt3VpWbHQnXRedVun/hC7sIyTGDGTfsGuXo4ebik2+3ShjcPbhtFwWDw==",
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+            "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
             "cpu": [
                 "x64"
             ],
@@ -646,9 +646,9 @@
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.19.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.9.tgz",
-            "integrity": "sha512-GQoa6OrQ8G08guMFgeXPH7yE/8Dt0IfOGWJSfSH4uafwdC7rWwrfE6P9N8AtPGIjUzdo2+7bN8Xo3qC578olhg==",
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+            "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
             "cpu": [
                 "arm64"
             ],
@@ -661,9 +661,9 @@
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.19.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.9.tgz",
-            "integrity": "sha512-UOozV7Ntykvr5tSOlGCrqU3NBr3d8JqPes0QWN2WOXfvkWVGRajC+Ym0/Wj88fUgecUCLDdJPDF0Nna2UK3Qtg==",
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+            "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
             "cpu": [
                 "ia32"
             ],
@@ -676,9 +676,9 @@
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.19.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.9.tgz",
-            "integrity": "sha512-oxoQgglOP7RH6iasDrhY+R/3cHrfwIDvRlT4CGChflq6twk8iENeVvMJjmvBb94Ik1Z+93iGO27err7w6l54GQ==",
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+            "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
             "cpu": [
                 "x64"
             ],
@@ -980,162 +980,6 @@
             "engines": {
                 "node": ">= 8"
             }
-        },
-        "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.7.0.tgz",
-            "integrity": "sha512-rGku10pL1StFlFvXX5pEv88KdGW6DHUghsxyP/aRYb9eH+74jTGJ3U0S/rtlsQ4yYq1Hcc7AMkoJOb1xu29Fxw==",
-            "cpu": [
-                "arm"
-            ],
-            "optional": true,
-            "os": [
-                "android"
-            ]
-        },
-        "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.7.0.tgz",
-            "integrity": "sha512-/EBw0cuJ/KVHiU2qyVYUhogXz7W2vXxBzeE9xtVIMC+RyitlY2vvaoysMUqASpkUtoNIHlnKTu/l7mXOPgnKOA==",
-            "cpu": [
-                "arm64"
-            ],
-            "optional": true,
-            "os": [
-                "android"
-            ]
-        },
-        "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.7.0.tgz",
-            "integrity": "sha512-4VXG1bgvClJdbEYYjQ85RkOtwN8sqI3uCxH0HC5w9fKdqzRzgG39K7GAehATGS8jghA7zNoS5CjSKkDEqWmNZg==",
-            "cpu": [
-                "arm64"
-            ],
-            "optional": true,
-            "os": [
-                "darwin"
-            ]
-        },
-        "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.7.0.tgz",
-            "integrity": "sha512-/ImhO+T/RWJ96hUbxiCn2yWI0/MeQZV/aeukQQfhxiSXuZJfyqtdHPUPrc84jxCfXTxbJLmg4q+GBETeb61aNw==",
-            "cpu": [
-                "x64"
-            ],
-            "optional": true,
-            "os": [
-                "darwin"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.7.0.tgz",
-            "integrity": "sha512-zhye8POvTyUXlKbfPBVqoHy3t43gIgffY+7qBFqFxNqVtltQLtWeHNAbrMnXiLIfYmxcoL/feuLDote2tx+Qbg==",
-            "cpu": [
-                "arm"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.7.0.tgz",
-            "integrity": "sha512-RAdr3OJnUum6Vs83cQmKjxdTg31zJnLLTkjhcFt0auxM6jw00GD6IPFF42uasYPr/wGC6TRm7FsQiJyk0qIEfg==",
-            "cpu": [
-                "arm64"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.7.0.tgz",
-            "integrity": "sha512-nhWwYsiJwZGq7SyR3afS3EekEOsEAlrNMpPC4ZDKn5ooYSEjDLe9W/xGvoIV8/F/+HNIY6jY8lIdXjjxfxopXw==",
-            "cpu": [
-                "arm64"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.7.0.tgz",
-            "integrity": "sha512-rlfy5RnQG1aop1BL/gjdH42M2geMUyVQqd52GJVirqYc787A/XVvl3kQ5NG/43KXgOgE9HXgCaEH05kzQ+hLoA==",
-            "cpu": [
-                "riscv64"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.7.0.tgz",
-            "integrity": "sha512-cCkoGlGWfBobdDtiiypxf79q6k3/iRVGu1HVLbD92gWV5WZbmuWJCgRM4x2N6i7ljGn1cGytPn9ZAfS8UwF6vg==",
-            "cpu": [
-                "x64"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.7.0.tgz",
-            "integrity": "sha512-R2oBf2p/Arc1m+tWmiWbpHBjEcJnHVnv6bsypu4tcKdrYTpDfl1UT9qTyfkIL1iiii5D4WHxUHCg5X0pzqmxFg==",
-            "cpu": [
-                "x64"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.7.0.tgz",
-            "integrity": "sha512-CPtgaQL1aaPc80m8SCVEoxFGHxKYIt3zQYC3AccL/SqqiWXblo3pgToHuBwR8eCP2Toa+X1WmTR/QKFMykws7g==",
-            "cpu": [
-                "arm64"
-            ],
-            "optional": true,
-            "os": [
-                "win32"
-            ]
-        },
-        "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.7.0.tgz",
-            "integrity": "sha512-pmioUlttNh9GXF5x2CzNa7Z8kmRTyhEzzAC+2WOOapjewMbl+3tGuAnxbwc5JyG8Jsz2+hf/QD/n5VjimOZ63g==",
-            "cpu": [
-                "ia32"
-            ],
-            "optional": true,
-            "os": [
-                "win32"
-            ]
-        },
-        "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.7.0.tgz",
-            "integrity": "sha512-SeZzC2QhhdBQUm3U0c8+c/P6UlRyBcLL2Xp5KX7z46WXZxzR8RJSIWL9wSUeBTgxog5LTPJuPj0WOT9lvrtP7Q==",
-            "cpu": [
-                "x64"
-            ],
-            "optional": true,
-            "os": [
-                "win32"
-            ]
         },
         "node_modules/@tabler/icons": {
             "version": "2.43.0",
@@ -1941,9 +1785,9 @@
             }
         },
         "node_modules/esbuild": {
-            "version": "0.19.9",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.9.tgz",
-            "integrity": "sha512-U9CHtKSy+EpPsEBa+/A2gMs/h3ylBC0H0KSqIg7tpztHerLi6nrrcoUJAkNCEPumx8yJ+Byic4BVwHgRbN0TBg==",
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+            "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
             "hasInstallScript": true,
             "bin": {
                 "esbuild": "bin/esbuild"
@@ -1952,28 +1796,28 @@
                 "node": ">=12"
             },
             "optionalDependencies": {
-                "@esbuild/android-arm": "0.19.9",
-                "@esbuild/android-arm64": "0.19.9",
-                "@esbuild/android-x64": "0.19.9",
-                "@esbuild/darwin-arm64": "0.19.9",
-                "@esbuild/darwin-x64": "0.19.9",
-                "@esbuild/freebsd-arm64": "0.19.9",
-                "@esbuild/freebsd-x64": "0.19.9",
-                "@esbuild/linux-arm": "0.19.9",
-                "@esbuild/linux-arm64": "0.19.9",
-                "@esbuild/linux-ia32": "0.19.9",
-                "@esbuild/linux-loong64": "0.19.9",
-                "@esbuild/linux-mips64el": "0.19.9",
-                "@esbuild/linux-ppc64": "0.19.9",
-                "@esbuild/linux-riscv64": "0.19.9",
-                "@esbuild/linux-s390x": "0.19.9",
-                "@esbuild/linux-x64": "0.19.9",
-                "@esbuild/netbsd-x64": "0.19.9",
-                "@esbuild/openbsd-x64": "0.19.9",
-                "@esbuild/sunos-x64": "0.19.9",
-                "@esbuild/win32-arm64": "0.19.9",
-                "@esbuild/win32-ia32": "0.19.9",
-                "@esbuild/win32-x64": "0.19.9"
+                "@esbuild/android-arm": "0.18.20",
+                "@esbuild/android-arm64": "0.18.20",
+                "@esbuild/android-x64": "0.18.20",
+                "@esbuild/darwin-arm64": "0.18.20",
+                "@esbuild/darwin-x64": "0.18.20",
+                "@esbuild/freebsd-arm64": "0.18.20",
+                "@esbuild/freebsd-x64": "0.18.20",
+                "@esbuild/linux-arm": "0.18.20",
+                "@esbuild/linux-arm64": "0.18.20",
+                "@esbuild/linux-ia32": "0.18.20",
+                "@esbuild/linux-loong64": "0.18.20",
+                "@esbuild/linux-mips64el": "0.18.20",
+                "@esbuild/linux-ppc64": "0.18.20",
+                "@esbuild/linux-riscv64": "0.18.20",
+                "@esbuild/linux-s390x": "0.18.20",
+                "@esbuild/linux-x64": "0.18.20",
+                "@esbuild/netbsd-x64": "0.18.20",
+                "@esbuild/openbsd-x64": "0.18.20",
+                "@esbuild/sunos-x64": "0.18.20",
+                "@esbuild/win32-arm64": "0.18.20",
+                "@esbuild/win32-ia32": "0.18.20",
+                "@esbuild/win32-x64": "0.18.20"
             }
         },
         "node_modules/escalade": {
@@ -4114,30 +3958,17 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.7.0.tgz",
-            "integrity": "sha512-7Kw0dUP4BWH78zaZCqF1rPyQ8D5DSU6URG45v1dqS/faNsx9WXyess00uTOZxKr7oR/4TOjO1CPudT8L1UsEgw==",
+            "version": "3.29.4",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
+            "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
             "bin": {
                 "rollup": "dist/bin/rollup"
             },
             "engines": {
-                "node": ">=18.0.0",
+                "node": ">=14.18.0",
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.7.0",
-                "@rollup/rollup-android-arm64": "4.7.0",
-                "@rollup/rollup-darwin-arm64": "4.7.0",
-                "@rollup/rollup-darwin-x64": "4.7.0",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.7.0",
-                "@rollup/rollup-linux-arm64-gnu": "4.7.0",
-                "@rollup/rollup-linux-arm64-musl": "4.7.0",
-                "@rollup/rollup-linux-riscv64-gnu": "4.7.0",
-                "@rollup/rollup-linux-x64-gnu": "4.7.0",
-                "@rollup/rollup-linux-x64-musl": "4.7.0",
-                "@rollup/rollup-win32-arm64-msvc": "4.7.0",
-                "@rollup/rollup-win32-ia32-msvc": "4.7.0",
-                "@rollup/rollup-win32-x64-msvc": "4.7.0",
                 "fsevents": "~2.3.2"
             }
         },
@@ -4698,28 +4529,28 @@
             }
         },
         "node_modules/vite": {
-            "version": "5.0.7",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.7.tgz",
-            "integrity": "sha512-B4T4rJCDPihrQo2B+h1MbeGL/k/GMAHzhQ8S0LjQ142s6/+l3hHTT095ORvsshj4QCkoWu3Xtmob5mazvakaOw==",
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
+            "integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
             "dependencies": {
-                "esbuild": "^0.19.3",
-                "postcss": "^8.4.32",
-                "rollup": "^4.2.0"
+                "esbuild": "^0.18.10",
+                "postcss": "^8.4.27",
+                "rollup": "^3.27.1"
             },
             "bin": {
                 "vite": "bin/vite.js"
             },
             "engines": {
-                "node": "^18.0.0 || >=20.0.0"
+                "node": "^14.18.0 || >=16.0.0"
             },
             "funding": {
                 "url": "https://github.com/vitejs/vite?sponsor=1"
             },
             "optionalDependencies": {
-                "fsevents": "~2.3.3"
+                "fsevents": "~2.3.2"
             },
             "peerDependencies": {
-                "@types/node": "^18.0.0 || >=20.0.0",
+                "@types/node": ">= 14",
                 "less": "*",
                 "lightningcss": "^1.21.0",
                 "sass": "*",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
         "laravel-vite-plugin": "^0.8.0",
-        "vite": "^5.0.7"
+        "vite": "^4.0.0"
     },
     "dependencies": {
         "@inertiajs/react": "^1.0.14",


### PR DESCRIPTION
Not compatible yet: https://github.com/laravel/vite-plugin/issues/265